### PR TITLE
esbuild migration

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
   "scripts": {
     "start": "./node_modules/web-ext/bin/web-ext run",
     "build": "./node_modules/web-ext/bin/web-ext build --overwrite-dest",
-    "start:parcel": "./node_modules/parcel-bundler/bin/cli.js index.ts",
-    "build:parcel": "./node_modules/parcel-bundler/bin/cli.js build index.ts"
+    "start:js": "npm run build:js -- --watch",
+    "build:js": "esbuild index.ts --outfile=dist/index.js --bundle --platform=browser --sourcemap --format=iife --target=es2020 --minify"
   },
   "author": "ParkSB",
   "license": "MPL2.0",
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@types/cheerio": "^0.22.12",
+    "esbuild": "^0.14.36",
     "tslint": "^5.18.0",
     "tslint-config-airbnb": "^5.11.1",
     "typescript": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -16,12 +16,10 @@
   "author": "ParkSB",
   "license": "MPL2.0",
   "dependencies": {
-    "cheerio": "^1.0.0-rc.10",
-    "request": "^2.88.0"
+    "cheerio": "^1.0.0-rc.10"
   },
   "devDependencies": {
     "@types/cheerio": "^0.22.12",
-    "@types/request": "^2.48.2",
     "parcel-bundler": "^1.12.3",
     "tslint": "^5.18.0",
     "tslint-config-airbnb": "^5.11.1",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
   },
   "devDependencies": {
     "@types/cheerio": "^0.22.12",
-    "parcel-bundler": "^1.12.3",
     "tslint": "^5.18.0",
     "tslint-config-airbnb": "^5.11.1",
     "typescript": "^3.5.3",

--- a/src/request.ts
+++ b/src/request.ts
@@ -1,0 +1,4 @@
+export const request = (url: string, callback: (err: any, res: any, body: string) => void) =>
+  fetch(url, { redirect: 'follow' })
+    .then((res) => res.text())
+    .then((body) => callback(null, null, body));

--- a/src/scrapers/JaDictNaver.ts
+++ b/src/scrapers/JaDictNaver.ts
@@ -1,4 +1,4 @@
-import request from 'request';
+import { request } from '../request';
 import cheerio from 'cheerio';
 
 import Tooltip from '../Tooltip';

--- a/src/scrapers/ZhDictNaver.ts
+++ b/src/scrapers/ZhDictNaver.ts
@@ -1,4 +1,4 @@
-import request from 'request';
+import { request } from '../request';
 import cheerio from 'cheerio';
 
 import Tooltip from '../Tooltip';


### PR DESCRIPTION
- note: parcel-bundler 지워버리는 김에 esbuild로 갈아봤습니다 (sourcemap이 프로젝트 루트에 따른 상대경로로 보입니다!)
- note 2: 불필요한 conflict을 방지하기 위해 `package-lock.json`은 첨가하지 않았습니다. `npm install` 등으로 업데이트가 필요합니다.