### PR TITLE
build: contain specific files only in extension file

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -18,7 +18,7 @@
   "content_scripts": [
     {
       "matches": ["<all_urls>"],
-      "js": ["dist/index.js"]
+      "js": ["index.js"]
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -8,10 +8,18 @@
     "npm": ">=8"
   },
   "scripts": {
-    "start": "./node_modules/web-ext/bin/web-ext run",
-    "build": "./node_modules/web-ext/bin/web-ext build --overwrite-dest",
+    "start": "web-ext run",
+    "build": "npm run build:js && npm run build:copy-asset && web-ext build",
+    "build:copy-asset": "cp -R icons/ manifest.json dist/",
     "start:js": "npm run build:js -- --watch",
     "build:js": "esbuild index.ts --outfile=dist/index.js --bundle --platform=browser --sourcemap --format=iife --target=es2020 --minify"
+  },
+  "webExt": {
+    "sourceDir": "dist/",
+    "artifactsDir": "web-ext-artifacts/",
+    "build": {
+      "overwriteDest": true
+    }
   },
   "author": "ParkSB",
   "license": "MPL2.0",


### PR DESCRIPTION
아무 설정 없이 `web-ext build`를 사용하면 `node_modules`을 제외한 (거의) 모든 파일이 extension에 담기게 됩니다[^1]. web-ext 설정을 건드려서 `dist/` 폴더 안쪽의 파일만 담기도록 해보았습니다.


[^1]: [web-ext command reference | Firefox Extension Workshop의 `--ignore-files` 옵션 설명](https://extensionworkshop.com/documentation/develop/web-ext-command-reference/#ignore-files)