### PR TITLE
build: fix cp command for GNU/BSD compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "scripts": {
     "start": "web-ext run",
     "build": "npm run build:js && npm run build:copy-asset && web-ext build",
-    "build:copy-asset": "cp -R icons/ manifest.json dist/",
+    "build:copy-asset": "cp -R icons/* manifest.json dist/",
     "start:js": "npm run build:js -- --watch",
     "build:js": "esbuild index.ts --outfile=dist/index.js --bundle --platform=browser --sourcemap --format=iife --target=es2020 --minify",
     "lint": "eslint --ignore-path=.gitignore --ext=ts .",


### PR DESCRIPTION
https://github.com/parksb/multilingual-fox/commit/fcfb64e16fd96b3aff24238c75f702a687ed9f4b#commitcomment-71886741

사실 Windows 생각하면 `cp` 대신 node.js 스크립트 하나 짜는 게 더 낫긴 한데... Windows를 누가 써요 `¯\_(ツ)_/¯`