### PR TITLE
Mitigate CSS pollution by `all: initial`

### DIFF
--- a/src/Tooltip.ts
+++ b/src/Tooltip.ts
@@ -10,6 +10,7 @@ class Tooltip {
     this.dom = document.createElement('div');
 
     Utils.set([this.dom])
+      .styleNonImportant('all', 'initial')
       .style('position', 'fixed')
       .style('display', 'block')
       .style('top', '5px')

--- a/src/Utils.ts
+++ b/src/Utils.ts
@@ -14,6 +14,14 @@ class Utils {
     return Utils;
   }
 
+  public static styleNonImportant(key: string, value: string) {
+    this.elements.forEach((element: HTMLElement) => {
+      element.style.setProperty(key, value);
+    });
+
+    return Utils;
+  }
+
   public static appendHTML(parent: HTMLElement, child: HTMLElement, content: string) {
     if (content) {
       const { body } = new DOMParser().parseFromString(content, 'text/html');


### PR DESCRIPTION
사이트의 CSS로 인해 형태가 바뀌는 것을 [`all: initial`](https://developer.mozilla.org/en-US/docs/Web/CSS/all)을 추가하여 최소화합니다.

| 사이트                 | 적용 전                      | 적용 후                      |
|------------------------|------------------------------|------------------------------|
| [haskellforall.com]    | ![Haskell for all - 적용 전] | ![Haskell for all - 적용 후] |
| [neodgm.dalgona.dev]\* | ![Neo둥근모 - 적용 전]       | ![Neo둥근모 - 적용 후]       |

\* [neodgm.dalgona.dev]의 경우 전역으로 `* { font-weight: normal !important; }`가 달려 있습니다.

[haskellforall.com]: https://www.haskellforall.com
[neodgm.dalgona.dev]: https://neodgm.dalgona.dev
[Haskell for all - 적용 전]: https://github.com/parksb/multilingual-fox/assets/3071003/c51c850e-a748-41a9-b720-c1c67548dfac
[Haskell for all - 적용 후]: https://github.com/parksb/multilingual-fox/assets/3071003/8ade8f22-e793-45e5-aa59-4e95f2a043e7
[Neo둥근모 - 적용 전]: https://github.com/parksb/multilingual-fox/assets/3071003/8a4674a4-4bf8-4f39-b896-34c941579376
[Neo둥근모 - 적용 후]: https://github.com/parksb/multilingual-fox/assets/3071003/63e5f21c-d17a-4e13-a6c3-6b3e9ede3253